### PR TITLE
Fix missing paren on package-requires

### DIFF
--- a/oc-csl-activate.el
+++ b/oc-csl-activate.el
@@ -4,7 +4,7 @@
 ;; Maintainer: András Simonyi <andras.simonyi@gmail.com>
 ;; URL: https://github.com/andras-simonyi/org-cite-csl-activate
 ;; Keywords: csl, org-mode, cite, bib
-;; Package-Requires: ((emacs "25.1") (org "9.5") (citeproc "0.9")
+;; Package-Requires: ((emacs "25.1") (org "9.5") (citeproc "0.9"))
 ;; Version: 0.0.1
 
 ;; Author: András Simonyi <andras.simonyi@gmail.com>


### PR DESCRIPTION
Not sure how this happened :-)

Also, I realized just after submitting this tiny PR, looks like you need to declare this function?

```
Warning (comp): oc-csl-activate.el:117:26: Warning: the function ‘citar-get-entry’ is not known to be defined
```