### PR TITLE
Add customizable fallback CSL style variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ in which case the CSL style and locale (org `#+language:` keyword) set in the do
 > :warning: **Warning:** Setting the `org-cite-csl-activate-use-document-style` variable to non-nil when a CSL style which doesn’t belong to the `author-date` category is used will almost certainly cause rendering problems.
 
 The default fallback CSL style can also be changed by setting the
-`org-cite-csl-activate-fallback-style` variable. This should be the file name of
-a CSL style located in `org-cite-csl-styles-dir`. The fallback is used when no
-CSL style is set in the document.
+`org-cite-csl-activate-fallback-style` variable. This should be the file name
+of a CSL style located in `org-cite-csl-styles-dir`. When set in conjunction
+with `org-cite-activate-use-document-style t`, the fallback is used when no CSL
+style is set in the document.
 
 ### Using the Citar cache for retrieving bibliographic entries
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ in which case the CSL style and locale (org `#+language:` keyword) set in the do
 
 > :warning: **Warning:** Setting the `org-cite-csl-activate-use-document-style` variable to non-nil when a CSL style which doesn’t belong to the `author-date` category is used will almost certainly cause rendering problems.
 
+The default fallback CSL style can also be changed by setting the
+`org-cite-csl-activate-fallback-style` variable. This should be the file name of
+a CSL style located in `org-cite-csl-styles-dir`. The fallback is used when no
+CSL style is set in the document.
+
 ### Using the Citar cache for retrieving bibliographic entries
 
 Users of [Citar](https://github.com/emacs-citar/citar) who want perfect

--- a/oc-csl-activate.el
+++ b/oc-csl-activate.el
@@ -51,9 +51,16 @@
 
 (defcustom org-cite-csl-activate-use-document-style nil
   "Whether to use the citation style of the current document.
-When nil, `org-cite-csl--fallback-style-file' is always used."
+When nil, `org-cite-csl-activate-fallback-style` is used if set,
+otherwise `org-cite-csl--fallback-style-file` is used."
   :type 'boolean
   :safe 'booleanp)
+
+(defcustom org-cite-csl-activate-fallback-style nil
+  "Fallback CSL style to use when no document style is set.
+If nil, `org-cite-csl--fallback-style-file` is used."
+  :type '(choice (const nil) string)
+  :group 'org-cite-csl-activate)
 
 (defcustom org-cite-csl-activate-use-document-locale nil
   "Whether to use the locale of the current document.
@@ -145,7 +152,9 @@ Return nil if there is no citation object at the position."
 	                    (cite-spec (when (stringp cite-string) (split-string cite-string "[ \t]"))))
                        (when (and cite-spec (string= "csl" (car cite-spec)) (cdr cite-spec))
 			 (expand-file-name (cadr cite-spec) org-cite-csl-styles-dir))))
-                   org-cite-csl--fallback-style-file)
+                   (if org-cite-csl-activate-fallback-style
+                       (expand-file-name org-cite-csl-activate-fallback-style org-cite-csl-styles-dir)
+                     org-cite-csl--fallback-style-file))
 	       (if org-cite-csl-activate-use-citar-cache
 		   (progn
 		    (org-cite-csl-activate--check-citar)


### PR DESCRIPTION
Thanks for your work on this package, very useful!

I'd like to suggest adding a customizable fallback CSL style variable: `org-cite-csl-activate-fallback-style`. 

This can be used either to affect all org documents, or when set alongside `org-cite-csl-activate-use-document-style`, as a fallback for documents without a style set within the document, e.g.
```
(setq org-cite-csl-activate-use-document-style t
        org-cite-csl-activate-fallback-style "apa.csl"))
```

Currently by default the fallback style is determined by oc-csl.el, where it's hard coded as Chicago author-date. The default style for export can be changed with `org-cite-export-processors` — this new variable makes it possible to do the same for org-cite-csl-activate.